### PR TITLE
main.goの修正提案

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,24 +116,29 @@ func handleLine(line string, configData map[string]map[string]*template.Template
 				continue
 			}
 			var buf bytes.Buffer
-			val := col.(*sqlparser.SQLVal)
-			switch val.Type {
-			case sqlparser.StrVal:
-				err = tmpl.Execute(&buf, &TemplateValue{Raw: string(val.Val), Salt: string(salt)})
-				if err != nil {
-					log.Fatal(err)
-				}
-				row[j] = sqlparser.NewStrVal(buf.Bytes())
-			case sqlparser.IntVal:
-				err = tmpl.Execute(&buf, &TemplateValue{Raw: string(val.Val), Salt: string(salt)})
-				if err != nil {
-					log.Fatal(err)
-				}
-				row[j] = sqlparser.NewIntVal(buf.Bytes())
-			}
-		}
-	}
-	return fmt.Sprintf("%s;", sqlparser.String(insert))
+			switch col.(type) {
+        　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　case *sqlparser.NullVal:
+            　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　row[j] = col
+        　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　case *sqlparser.SQLVal:
+            　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　val := col.(*sqlparser.SQLVal)
+            　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　switch val.Type {
+            　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　case sqlparser.StrVal:
+                　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　err = tmpl.Execute(&buf, &TemplateValue{Raw: string(val.Val), Salt: string(salt)})
+                　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　if err != nil {
+                    　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　log.Fatal(err)
+                　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　}
+                　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　row[j] = sqlparser.NewStrVal(buf.Bytes())
+            　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　case sqlparser.IntVal:
+                　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　err = tmpl.Execute(&buf, &TemplateValue{Raw: string(val.Val), Salt: string(salt)})
+                　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　if err != nil {
+                    　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　log.Fatal(err)
+                　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　}　
+                　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　row[j] = sqlparser.NewIntVal(buf.Bytes())
+            　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　}
+        　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　}
+    　　　　　　　　　　　　　　　　　　　　　　　　　　　　}
+　　　　　　　　　　　　　　　　　}
+　　　　　　　　　　　　　　　　　return fmt.Sprintf("%s;", sqlparser.String(insert))
 }
 
 func main() {


### PR DESCRIPTION
@tamurayoshiya 
`null`を受け取った際に`panic`になるため、備考など`null`を含むカラムを処理できませんでした。
`null`を受け取った際にはそのまま`null`を返す分岐を追加をしました。